### PR TITLE
TASK: Minor code reordering and add type hints

### DIFF
--- a/Classes/Domain/Repository/NodeEventRepository.php
+++ b/Classes/Domain/Repository/NodeEventRepository.php
@@ -18,41 +18,52 @@ class NodeEventRepository extends EventRepository
     /**
      * Find all events which are "top-level" and in a given workspace (or are not NodeEvents)
      *
-     * @param integer $offset
-     * @param integer $limit
+     * @param int $offset
+     * @param int $limit
      * @param string $workspaceName
      * @param string $siteIdentifier
      * @param string $nodeIdentifier
      * @param string $accountIdentifier
+     *
      * @return QueryResultInterface
      */
-    public function findRelevantEventsByWorkspace($offset, $limit, $workspaceName, $siteIdentifier = null, $nodeIdentifier = null, $accountIdentifier = null)
-    {
+    public function findRelevantEventsByWorkspace(
+        $offset,
+        $limit,
+        $workspaceName,
+        string $siteIdentifier = null,
+        string $nodeIdentifier = null,
+        string $accountIdentifier = null
+    ) : QueryResultInterface {
         $query = $this->prepareRelevantEventsQuery();
-        $query->getQueryBuilder()
+        $queryBuilder = $query->getQueryBuilder();
+        $queryBuilder
             ->andWhere('e.workspaceName = :workspaceName AND e.eventType = :eventType')
             ->setParameter('workspaceName', $workspaceName)
-            ->setParameter('eventType', 'Node.Published');
-        if ($siteIdentifier) {
+            ->setParameter('eventType', 'Node.Published')
+        ;
+        if ($siteIdentifier !== null) {
             $siteCondition = '%' . trim(json_encode(['site' => $siteIdentifier], JSON_PRETTY_PRINT), "{}\n\t ") . '%';
-            $query->getQueryBuilder()
+            $queryBuilder
                 ->andWhere('NEOSCR_TOSTRING(e.data) LIKE :site')
-                ->setParameter('site', $siteCondition);
+                ->setParameter('site', $siteCondition)
+            ;
         }
-        if ($nodeIdentifier) {
-            $query->getQueryBuilder()
+        if ($nodeIdentifier !== null) {
+            $queryBuilder
                 ->andWhere('e.nodeIdentifier = :nodeIdentifier')
-                ->setParameter('nodeIdentifier', $nodeIdentifier);
+                ->setParameter('nodeIdentifier', $nodeIdentifier)
+            ;
         }
-        if ($accountIdentifier) {
-            $query->getQueryBuilder()
+        if ($accountIdentifier !== null) {
+            $queryBuilder
                 ->andWhere('e.accountIdentifier = :accountIdentifier')
-                ->setParameter('accountIdentifier', $accountIdentifier);
+                ->setParameter('accountIdentifier', $accountIdentifier)
+            ;
         }
-        $query->getQueryBuilder()->setFirstResult($offset);
-        $query->getQueryBuilder()->setMaxResults($limit);
+        $queryBuilder->setFirstResult($offset);
+        $queryBuilder->setMaxResults($limit);
 
         return $query->execute();
     }
-
 }

--- a/Classes/ViewHelpers/AssetExistsViewHelper.php
+++ b/Classes/ViewHelpers/AssetExistsViewHelper.php
@@ -6,12 +6,8 @@ use Neos\Flow\Annotations as Flow;
 use Neos\FluidAdaptor\Core\ViewHelper\AbstractViewHelper;
 use Neos\Media\Domain\Model\AssetInterface;
 
-/**
- *
- */
 class AssetExistsViewHelper extends AbstractViewHelper
 {
-
     /**
      * @var boolean
      */
@@ -21,15 +17,17 @@ class AssetExistsViewHelper extends AbstractViewHelper
      * Checks if an asset exists.
      *
      * @param AssetInterface $asset
+     *
      * @return string
      */
-    public function render(AssetInterface $asset)
+    public function render(AssetInterface $asset) : string
     {
         try {
             $asset->getResource();
         } catch (EntityNotFoundException $e) {
             return '';
         }
+
         return $this->renderChildren();
     }
 }

--- a/Classes/ViewHelpers/NodeTypeIconViewHelper.php
+++ b/Classes/ViewHelpers/NodeTypeIconViewHelper.php
@@ -5,12 +5,8 @@ use Neos\Flow\Annotations as Flow;
 use Neos\FluidAdaptor\Core\ViewHelper\AbstractViewHelper;
 use Neos\ContentRepository\Domain\Service\NodeTypeManager;
 
-/**
- *
- */
 class NodeTypeIconViewHelper extends AbstractViewHelper
 {
-
     /**
      * @var boolean
      */
@@ -24,9 +20,10 @@ class NodeTypeIconViewHelper extends AbstractViewHelper
 
     /**
      * @param string $nodeType
+     *
      * @return string
      */
-    public function render($nodeType)
+    public function render(string $nodeType) : string
     {
         return $this->nodeTypeManager->getNodeType($nodeType)->getConfiguration('ui.icon');
     }


### PR DESCRIPTION
Mostly alphabetically reorderings. Added some line breaks for long lines.

Type hints in PHPDoc as well as for the method parameters. Return type `void` only available since PHP 7.1, therefore not added yet.