### PR TITLE
BUGFIX: Full compatibility with Neos 5.0

### DIFF
--- a/Classes/Controller/HistoryController.php
+++ b/Classes/Controller/HistoryController.php
@@ -4,7 +4,6 @@ namespace AE\History\Controller;
 use AE\History\Domain\Repository\NodeEventRepository;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Mvc\View\ViewInterface;
-use Neos\Flow\Security\Account;
 use Neos\Flow\Security\Context;
 use Neos\Fusion\View\FusionView;
 use Neos\Neos\Controller\CreateContentContextTrait;

--- a/Classes/ViewHelpers/AssetExistsViewHelper.php
+++ b/Classes/ViewHelpers/AssetExistsViewHelper.php
@@ -3,41 +3,42 @@ namespace AE\History\ViewHelpers;
 
 use Doctrine\ORM\EntityNotFoundException;
 use Neos\Flow\Annotations as Flow;
-use Neos\FluidAdaptor\Core\ViewHelper\AbstractViewHelper;
+use Neos\FluidAdaptor\Core\ViewHelper\AbstractConditionViewHelper;
+use Neos\FluidAdaptor\Core\ViewHelper\Exception as ViewHelperException;
 use Neos\Media\Domain\Model\AssetInterface;
+use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 
-class AssetExistsViewHelper extends AbstractViewHelper
+/**
+ * Checks if an asset exists.
+ */
+class AssetExistsViewHelper extends AbstractConditionViewHelper
 {
     /**
-     * @var boolean
+     * @return void
+     *
+     * @throws ViewHelperException
      */
-    protected $escapeOutput = false;
-
-    /**
-     * @throws \Neos\FluidAdaptor\Core\ViewHelper\Exception
-     */
-    public function initializeArguments()
+    public function initializeArguments() : void
     {
-        parent::initializeArguments();
-
-        $this->registerArgument('asset', AssetInterface::class, 'AssetInterface', true);
+        $this->registerArgument('asset', AssetInterface::class, 'The asset to check for existence.', true);
+        $this->registerArgument('then', 'mixed', 'Value to be returned if the asset exists.', false);
+        $this->registerArgument('else', 'mixed', 'Value to be returned if the asset doesn\'t exist.', false);
     }
 
     /**
-     * Checks if an asset exists.
+     * @param array|null $arguments
+     * @param RenderingContextInterface $renderingContext
      *
-     * @return string
+     * @return bool
      */
-    public function render() : string
+    protected static function evaluateCondition($arguments = null, RenderingContextInterface $renderingContext) : bool
     {
-        $asset = $this->arguments['asset'];
-
         try {
-            $asset->getResource();
-        } catch (EntityNotFoundException $e) {
-            return '';
+            $arguments['asset']->getResource();
+        } catch (EntityNotFoundException $exception) {
+            return false;
         }
 
-        return $this->renderChildren();
+        return true;
     }
 }

--- a/Classes/ViewHelpers/DiffViewHelper.php
+++ b/Classes/ViewHelpers/DiffViewHelper.php
@@ -7,10 +7,15 @@ use Neos\Diff\Diff;
 use Neos\Diff\Renderer\Html\HtmlArrayRenderer;
 use Neos\Flow\Annotations as Flow;
 use Neos\FluidAdaptor\Core\ViewHelper\AbstractViewHelper;
+use Neos\FluidAdaptor\Core\ViewHelper\Exception as ViewHelperException;
 use Neos\Media\Domain\Model\AssetInterface;
 use Neos\Media\Domain\Model\ImageInterface;
 use Neos\Neos\EventLog\Domain\Model\NodeEvent;
 
+/**
+ * Renders the difference between the original and the changed content of the given node and returns it, along with meta
+ * information, in an array.
+ */
 class DiffViewHelper extends AbstractViewHelper
 {
     /**
@@ -25,17 +30,24 @@ class DiffViewHelper extends AbstractViewHelper
     protected $nodeTypeManager;
 
     /**
-     * Renders the difference between the original and the changed content of the given node and returns it, along
-     * with meta information, in an array.
+     * @return void
      *
+     * @throws ViewHelperException
+     */
+    public function initializeArguments() : void
+    {
+        parent::initializeArguments();
+
+        $this->registerArgument('nodeEvent', NodeEvent::class, 'The NodeEvent to extract the diff from.', true);
+    }
+
+    /**
      * @return string
      * @throws \Neos\ContentRepository\Exception\NodeTypeNotFoundException
      */
     public function render() : string
     {
-        $nodeEvent = $this->arguments['nodeEvent'];
-
-        $data = $nodeEvent->getData();
+        $data = $this->arguments['nodeEvent']->getData();
         $old = $data['old'];
         $new = $data['new'];
         $nodeType = $this->nodeTypeManager->getNodeType($data['nodeType']);

--- a/Classes/ViewHelpers/NodeTypeIconViewHelper.php
+++ b/Classes/ViewHelpers/NodeTypeIconViewHelper.php
@@ -4,6 +4,7 @@ namespace AE\History\ViewHelpers;
 use Neos\Flow\Annotations as Flow;
 use Neos\FluidAdaptor\Core\ViewHelper\AbstractViewHelper;
 use Neos\ContentRepository\Domain\Service\NodeTypeManager;
+use Neos\FluidAdaptor\Core\ViewHelper\Exception as ViewHelperException;
 
 class NodeTypeIconViewHelper extends AbstractViewHelper
 {
@@ -19,13 +20,15 @@ class NodeTypeIconViewHelper extends AbstractViewHelper
     protected $nodeTypeManager;
 
     /**
-     * @throws \Neos\FluidAdaptor\Core\ViewHelper\Exception
+     * @return void
+     *
+     * @throws ViewHelperException
      */
-    public function initializeArguments()
+    public function initializeArguments() : void
     {
         parent::initializeArguments();
 
-        $this->registerArgument('nodeType', 'string', 'NodeType', true);
+        $this->registerArgument('nodeType', 'string', 'The name of the NodeType.', true);
     }
 
     /**
@@ -34,8 +37,6 @@ class NodeTypeIconViewHelper extends AbstractViewHelper
      */
     public function render() : string
     {
-        $nodeType = $this->arguments['nodeType'];
-
-        return $this->nodeTypeManager->getNodeType($nodeType)->getConfiguration('ui.icon');
+        return $this->nodeTypeManager->getNodeType($this->arguments['nodeType'])->getConfiguration('ui.icon');
     }
 }


### PR DESCRIPTION
v2.0.7 already adjusted some of the code, but the `DiffViewHelper` still was missing the `initializeArguments` method.

For the `AssetExistsViewHelper`, I extended the `AbstractConditionViewHelper` to be able to use the usual then/else.
This change should not be breaking.