### PR TITLE
BUGFIX: Deprecation warning (PHP 8)

### DIFF
--- a/Classes/ViewHelpers/AssetExistsViewHelper.php
+++ b/Classes/ViewHelpers/AssetExistsViewHelper.php
@@ -31,7 +31,7 @@ class AssetExistsViewHelper extends AbstractConditionViewHelper
      *
      * @return bool
      */
-    protected static function evaluateCondition($arguments = null, RenderingContextInterface $renderingContext) : bool
+    protected static function evaluateCondition($arguments, RenderingContextInterface $renderingContext) : bool
     {
         try {
             $arguments['asset']->getResource();


### PR DESCRIPTION
This fix removes the warning 
`PHP Deprecated:  Required parameter $renderingContext follows optional parameter $arguments in Classes/ViewHelpers/AssetExistsViewHelper.php on line 34`