### PR TITLE
TASK: Neos >7 compatibility

### DIFF
--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -9,6 +9,10 @@ Neos:
             controller: \AE\History\Controller\HistoryController
             privilegeTarget: 'AE.History:BackendModule'
             additionalResources:
+              javaScripts:
+                - 'resource://Neos.Media.Browser/Public/Libraries/jquery/jquery-3.6.0.min.js'
+                - 'resource://Neos.Twitter.Bootstrap/Public/2/js/bootstrap.min.js'
+                - 'resource://Neos.Media.Browser/Public/Libraries/bootstrap/bootstrap-components.js'
               styleSheets:
                 - 'resource://AE.History/Public/Styles/Module.css'
     userInterface:

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         }
     ],
     "require": {
-        "neos/neos": ">3"
+        "neos/neos": ">7"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Since the release of NEOS 7.x the load more button doesn't work because I think the backend UI dropped the default loading of jquery. With this fix the filters and load more button works with NEOS 7 and 8.

This fix was mentioned by @markusguenther during a slack discussion about this issue.

There is still a js error in the backend related to the popup's because require.js is not available anymore, but at least the main feature is working again.